### PR TITLE
Adjust "Compile Examples" workflow for Seeed boards

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -25,7 +25,9 @@ jobs:
     env:
       # sketch paths to compile (recursive) compatible with all boards
       UNIVERSAL_SKETCH_PATHS: |
+        - libraries/PDM
         - libraries/Scheduler
+        - libraries/USBHID
       SKETCHES_REPORTS_PATH: sketches-reports
 
     strategy:
@@ -33,63 +35,35 @@ jobs:
 
       matrix:
         board:
-          - fqbn: arduino:mbed:nano33ble
-          - fqbn: arduino:mbed:envie_m4
-          - fqbn: arduino:mbed:envie_m7
-          - fqbn: arduino:mbed:nanorp2040connect
-          - fqbn: arduino:mbed:nicla_sense
+          - fqbn: Seeeduino:nrf52:xiaonRF52840Sense
+            type: nrf52
+          - fqbn: Seeeduino:rp2040:wio_pico
+            type: rp2040
+          - fqbn: Seeeduino:rp2040:xiao_pico
+            type: rp2040
 
-        # compile only the examples compatible with each board
+        # Make board type-specific configurations
         include:
           - board:
-              fqbn: arduino:mbed:nano33ble
+              type: nrf52
+            platforms: |
+              # Use Boards Manager to install the latest release of the platform to get the toolchain
+              - source-url: "https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json"
+                name: "Seeeduino:nrf52"
+              # Overwrite the Board Manager installation with the local platform
+              - source-path: "./"
+                name: "Seeeduino:nrf52"
             additional-sketch-paths: |
-              - libraries/PDM
               - libraries/ThreadDebug
-              - libraries/USBHID
               - libraries/USBMSD/examples/Nano33BLE_FlashMassStorage
           - board:
-              fqbn: arduino:mbed:envie_m4
-            additional-libraries: |
-              - name: lvgl
-            additional-sketch-paths: |
-              - libraries/doom
-              - libraries/KernelDebug
-              - libraries/Portenta_SDCARD
-              - libraries/Portenta_SDRAM
-              - libraries/Portenta_Video
-              - libraries/RPC
-          - board:
-              fqbn: arduino:mbed:envie_m7
-            additional-libraries: |
-              - name: lvgl
-                version: 7.11.0
-            additional-sketch-paths: |
-              - libraries/PDM
-              - libraries/doom
-              - libraries/KernelDebug
-              - libraries/Portenta_Camera/examples
-              - libraries/Portenta_lvgl/examples/Portenta_lvgl
-              - libraries/Portenta_SDCARD
-              - libraries/Portenta_SDRAM
-              - libraries/Portenta_System
-              - libraries/Portenta_Video
-              - libraries/RPC
-              - libraries/ThreadDebug
-              - libraries/USBHID
-              - libraries/USBHOST
-              - libraries/USBMSD/examples/AccessFlashAsUSBDisk
-              - libraries/WiFi
-          - board:
-              fqbn: arduino:mbed:nanorp2040connect
-            additional-sketch-paths: |
-              - libraries/PDM
-              - libraries/USBHID
-              - ~/Arduino/libraries/WiFiNINA
-          - board:
-              fqbn: arduino:mbed:nicla_sense
-            additional-sketch-paths: |
-              - libraries/Nicla_System
+              type: rp2040
+            platforms: |
+              - source-url: "https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json"
+                name: "Seeeduino:rp2040"
+              - source-path: "./"
+                name: "Seeeduino:rp2040"
+            additional-sketch-paths:
 
     steps:
       - name: Checkout repository
@@ -110,15 +84,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fqbn: ${{ matrix.board.fqbn }}
-          libraries: |
-            - name: WiFiNINA
-            ${{ matrix.additional-libraries }}
-          platforms: |
-            # Use Board Manager to install the latest release of Arduino mbed Boards to get the toolchain
-            - name: "arduino:mbed"
-            # Overwrite the Board Manager installation with the local platform
-            - source-path: "./"
-              name: "arduino:mbed"
+          platforms: ${{ matrix.platforms }}
           sketch-paths: |
             ${{ env.UNIVERSAL_SKETCH_PATHS }}
             ${{ matrix.additional-sketch-paths }}


### PR DESCRIPTION
The "Compile Examples" GitHub Actions workflow compiles example sketches of the platform bundled libraries for each of the platform's boards on every push, pull request, and periodically. This provides a basic "smoke test" for the platform.

The workflow originated from the "Arduino Mbed OS Boards" platform, and thus was configured to compile for those boards. It must be reconfigured here to install the correct toolchain and compile for Seeed Studio's boards of the platform.

I see that all the original Arduino boards definitions are still in the platform, but I'm assuming you will eventually remove those so I have also removed their compilations from the workflow.

---

## Notes

### Seeed XIAO nRF52840 Sense

The job is failing due to this error while installing the platform:

```
Running command: /home/runner/bin/arduino-cli core install --additional-urls https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json Seeeduino:nrf52 

[...]

  Installing platform Seeeduino:nrf52@2.5.2...
  Error during install: Cannot install platform: installing platform Seeeduino:nrf52@2.5.2: searching package root dir: no unique root dir in archive, found '/home/runner/.arduino15/tmp/package-994337494/bootloaders' and '/home/runner/.arduino15/tmp/package-994337494/cores'
```

This is a valid failure caused by an invalid structure of the platform archive file:
https://files.seeedstudio.com/arduino/core/nRF52840/Seeed_XIAO_BLE_nRF52840_Sense.tar.bz2
Learn about the required structure of the archive here:
https://arduino.github.io/arduino-cli/latest/package_index_json-specification/#installation-archive-structure

You can reproduce the issue locally [with Arduino CLI](https://arduino.github.io/arduino-cli/latest/) by running this command:

```
arduino-cli core install --additional-urls https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json Seeeduino:nrf52 
```

### WIO_RP2040_MINI_DEV_BOARD and SEEED_XIAO_RP2040

Compilation for these boards is failing due to the following error:

```
Error during build: fork/exec /bin/arm-none-eabi-g++: no such file or directory
```

Line 63 of the workflow was intended to install the toolchain for these boards:

```yaml
                name: "Seeeduino:rp2040"
```

It looks like this is actually a completely different platform, thus the error. However, I did not see any other RP2040 platform in [the Seeed Studio package index](https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json), so I was not able to resolve the issue.

My intention here was more to provide you with a starting place you can work from to finally achieve the CI configuration you need, since I don't have enough information about this project to be able to do that for you.

### Sketch selection

You should review the configuration of which sketches are compiled for the boards ([`sketch-paths` input of the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches#sketch-paths)) because this determines the coverage of the project.

You are not limited to the sketches contained in this repository. You can install additional libraries and standalone sketches as needed. There is an example of that practice here:

https://github.com/arduino/ArduinoCore-megaavr/blob/master/.github/workflows/compile-examples.yml

Make sure to update the workflow for the additional  whenever you add new libraries or boards. It will only compile the sketches under the defined paths, so if you forget to do that then you will not have any coverage of the newly added sketches.

### Package index caching

I had an odd problem where the workflow was failing due to getting an outdated version of https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json, even though I could see the new version by visiting that page in my browser. The up to date version took some hours to become available. I'm not sure what caused that (perhaps CDN caching or caching in the GitHub Actions system?), but it might cause you confusion while making changes to the package index and so I thought I would mention it.

## References

- [GitHub Actions workflow syntax](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions)
- [Documentation for usage of `arduino/compile-sketches` GitHub Actions action](https://github.com/arduino/compile-sketches#readme)

---

Resolves https://github.com/arduino/ArduinoCore-mbed/issues/380