### PR TITLE
Add protocol-explicit `upload.tool` properties required for pluggable discovery compatibility

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -40,6 +40,7 @@ xiaonRF52840.upload_port.2.pid=0x0145
 
 xiaonRF52840.bootloader.tool=bootburn
 xiaonRF52840.upload.tool=nrfutil
+xiaonRF52840.upload.tool.default=nrfutil
 xiaonRF52840.upload.protocol=nrfutil
 xiaonRF52840.upload.use_1200bps_touch=true
 xiaonRF52840.upload.wait_for_upload_port=true
@@ -95,6 +96,7 @@ xiaonRF52840Sense.upload_port.2.pid=0x0145
 
 xiaonRF52840Sense.bootloader.tool=bootburn
 xiaonRF52840Sense.upload.tool=nrfutil
+xiaonRF52840Sense.upload.tool.default=nrfutil
 xiaonRF52840Sense.upload.protocol=nrfutil
 xiaonRF52840Sense.upload.use_1200bps_touch=true
 xiaonRF52840Sense.upload.wait_for_upload_port=true


### PR DESCRIPTION
A new flexible and powerful ["pluggable discovery" system](https://arduino.github.io/arduino-cli/latest/platform-specification/#pluggable-discovery) was added to the Arduino boards platform framework. This system makes it easy for Arduino boards platform authors to use any arbitrary communication channel between the board and development tools.

Boards platform configurations that use the old property syntax are automatically translated to the new syntax by Arduino CLI:

https://arduino.github.io/arduino-cli/latest/platform-specification/#sketch-upload-configuration

> For backward compatibility with IDE 1.8.15 and older the previous syntax is still supported

This translation is only done in platforms that use the old syntax exclusively. If `pluggable_discovery` properties are defined for the platform then the new pluggable discovery-style `upload.tool.<protocol_name>` properties must be defined for each board as well.

This platform uses the new pluggable discovery platform properties syntax, so those properties are required.

The required properties are missing, which causes uploads to fail for users of the recent versions of Arduino IDE and Arduino CLI (https://github.com/Seeed-Studio/ArduinoCore-mbed/issues/11) with an error of the form:

```text
Error during Upload: Property 'upload.tool.<protocol_name>' is undefined
```

(where `<protocol_name>` is the protocol of the selected port, if any)

It is also important to provide compatibility with versions of Arduino development tools from before the introduction of the modern pluggable discovery system. For this reason, the old style `<board ID>.upload.tool` properties are retained. Old versions of the development tools will treat the `<board ID>.upload.tool.<protocol_name>` properties as an unused arbitrary user defined property with no special significance and the new versions of the development tools will do the same for the `<board ID>.upload.tool` properties.

---

Originally reported at:

- https://github.com/Seeed-Studio/ArduinoCore-mbed/issues/11
- https://forum.arduino.cc/t/2-0-3-compilation-error-invalid-option-softdevice/1063253/7
- https://forum.arduino.cc/t/xiao-boards-property-upload-tool-serial-is-undefined/1035010/1
- https://forum.arduino.cc/t/xiao-boards-property-upload-tool-serial-is-undefined/1035010/11
- https://forum.arduino.cc/t/xiao-boards-property-upload-tool-serial-is-undefined/1035010/14
- https://forum.arduino.cc/t/xiao-boards-property-upload-tool-serial-is-undefined/1064096

---

Fixes https://github.com/Seeed-Studio/ArduinoCore-mbed/issues/11